### PR TITLE
Build and push image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,6 @@ jobs:
 
       - run: |
           cd wordpress-k8s-rds/cnab
-          docker_image = bitnami/wordpress-k8s-rds-cnab:devel
+          docker_image=bitnami/wordpress-k8s-rds-cnab:devel
           docker build -t ${docker_image} .
           docker push ${docker_image}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,10 @@
 version: 2
 jobs:
   build:
-    machine: true
+    docker:
+      - image: circleci/golang:1.11
     steps:
+      - setup_remote_docker
       - checkout
+      - run: |
+        docker login -u $DOCKER_USER -p $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,4 +7,8 @@ jobs:
       - setup_remote_docker
       - checkout
       - run: |
-         docker login -u $DOCKER_USER -p $DOCKER_PASS
+          docker login -u $DOCKER_USER -p $DOCKER_PASS
+
+      - run: |
+          cd wordpress-k8s-rds/cnab
+          docker build -t test-todo:$CIRCLE_BRANCH .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,11 @@
+# Basic, temporary safety-net build script to cover developers from forgetting to push images
+# 1 - Builds a docker image based on the cnab invocation image
+# 2 - Tags it and pushes it to the publish repository
 version: 2
 jobs:
   build:
+    branches:
+      only: master
     docker:
       - image: circleci/golang:1.11
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2
 jobs:
- build:
-   machine: true
-   steps:
-     - checkout
-     - run: |
-         docker login -u $DOCKER_USER -p $DOCKER_PASS
+  build:
+    machine: true
+    steps:
+      - checkout
+      - run: |
+        docker login -u $DOCKER_USER -p $DOCKER_PASS
 
-     - run: |
-       cd wordpress-k8s-rds/cnab
-       docker build -t test-todo:$CIRCLE_BRANCH .
+      - run: |
+        cd wordpress-k8s-rds/cnab
+        docker build -t test-todo:$CIRCLE_BRANCH .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@
 version: 2
 jobs:
   build:
-    branches:
-      only: master
+    # branches:
+    #   only: master
     docker:
       - image: circleci/golang:1.11
     steps:
@@ -22,5 +22,17 @@ jobs:
           cd wordpress-k8s-rds
           image_name=$(grep '"image":' bundle.cnab  | awk -F': ' '{print $2}' | awk -F'\"' '{print $2}')
 
-          docker build -t ${image_name} ./cnab
-          docker push ${image_name}
+          # Only build and push if the image has not already being published. This is a temporary workaround
+          # Ideally we would like to check the digest of the image and compare it with the one
+          # in the bundle.cnab file. This is not currently possible https://github.com/deislabs/duffle/issues/392
+
+          # Split name and tag
+          FS=':' read -r -a image_info <<< ${image_name}
+
+          if $(curl -s -f -lSL https://index.docker.io/v1/repositories/${image_info[0]}/tags/${image_info[1]}); then
+            echo "docker image exists"
+          else
+            echo "docker image does not exist"
+            docker build -t ${image_name} ./cnab
+            # docker push ${image_name}
+          fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,6 @@ jobs:
 
       - run: |
           cd wordpress-k8s-rds/cnab
-          local docker_image = bitnami/wordpress-k8s-rds-cnab:devel
+          docker_image = bitnami/wordpress-k8s-rds-cnab:devel
           docker build -t ${docker_image} .
           docker push ${docker_image}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,9 @@
 # Basic, temporary safety-net build script to cover developers from forgetting to push images
+# NOTE: It is not the best solution since it pushes the image after the code has been merged so references
+# to a non-existing image might exist, that said it is an easy temporary workaround.
+# The main issue is that we do not have implemented a release process yet.
+# TODO: Build the image as part of a bundle release process
+# It takes care of:
 # 1 - Builds a docker image based on the cnab invocation image
 # 2 - Tags it and pushes it to the publish repository
 version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,4 +11,6 @@ jobs:
 
       - run: |
           cd wordpress-k8s-rds/cnab
-          docker build -t test-todo:$CIRCLE_BRANCH .
+          local docker_image = bitnami/wordpress-k8s-rds-cnab:devel
+          docker build -t ${docker_image} .
+          docker push ${docker_image}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,8 @@ jobs:
           # Only build and push if the image has not already being published. This is a temporary workaround
           # Ideally we would like to check the digest of the image and compare it with the one
           # in the bundle.cnab file. This is not currently possible https://github.com/deislabs/duffle/issues/392
-          if $(docker pull $image_name > /dev/null) then
+          # NOTE that docker pull is quite ineficient for this task
+          if $(docker pull $image_name > /dev/null); then
             echo "docker image exists"
           else
             echo "docker image does not exist"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,7 @@ jobs:
           cd wordpress-k8s-rds
           image_name=$(grep '"image":' bundle.cnab  | awk -F': ' '{print $2}' | awk -F'\"' '{print $2}')
           echo $image_name
-      - run: |
-          echo $image_name
-          cd wordpress-k8s-rds/cnab
+
           docker_image=bitnami/wordpress-k8s-rds-cnab:devel
-          docker build -t ${docker_image} .
+          docker build -t ${docker_image} ./cnab
           docker push ${docker_image}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,12 +8,9 @@ jobs:
       - checkout
       - run: |
           docker login -u $DOCKER_USER -p $DOCKER_PASS
-
       - run: |
           cd wordpress-k8s-rds
           image_name=$(grep '"image":' bundle.cnab  | awk -F': ' '{print $2}' | awk -F'\"' '{print $2}')
-          echo $image_name
 
-          docker_image=bitnami/wordpress-k8s-rds-cnab:devel
-          docker build -t ${docker_image} ./cnab
-          docker push ${docker_image}
+          docker build -t ${image_name} ./cnab
+          docker push ${image_name}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,6 @@ jobs:
      - run: |
          docker login -u $DOCKER_USER -p $DOCKER_PASS
 
-     # build the application image
      - run: |
        cd wordpress-k8s-rds/cnab
        docker build -t test-todo:$CIRCLE_BRANCH .
-
-     # deploy the image
-     # - run: docker push company/app:$CIRCLE_BRANCH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2
+jobs:
+ build:
+   machine: true
+   steps:
+     - checkout
+     - run: |
+         docker login -u $DOCKER_USER -p $DOCKER_PASS
+
+     # build the application image
+     - run: |
+       cd wordpress-k8s-rds/cnab
+       docker build -t test-todo:$CIRCLE_BRANCH .
+
+     # deploy the image
+     # - run: docker push company/app:$CIRCLE_BRANCH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@
 version: 2
 jobs:
   build:
-    # branches:
-    #   only: master
+    branches:
+      only: master
     docker:
       - image: circleci/golang:1.11
     steps:
@@ -31,5 +31,5 @@ jobs:
           else
             echo "docker image does not exist"
             docker build -t ${image_name} ./cnab
-            # docker push ${image_name}
+            docker push ${image_name}
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,14 +25,7 @@ jobs:
           # Only build and push if the image has not already being published. This is a temporary workaround
           # Ideally we would like to check the digest of the image and compare it with the one
           # in the bundle.cnab file. This is not currently possible https://github.com/deislabs/duffle/issues/392
-
-          # Split name and tag
-          FS=':' read -r -a image_info <<< ${image_name}
-
-          image_url="https://index.docker.io/v1/repositories/${image_info[0]}/tags/${image_info[1]}"
-          echo $image_name
-          echo $image_url
-          if $(curl -s -f -lSL $image_url); then
+          if $(docker pull $image_name > /dev/null) then
             echo "docker image exists"
           else
             echo "docker image does not exist"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,9 @@ jobs:
           # Split name and tag
           FS=':' read -r -a image_info <<< ${image_name}
 
-          if $(curl -s -f -lSL https://index.docker.io/v1/repositories/${image_info[0]}/tags/${image_info[1]}); then
+          image_url="https://index.docker.io/v1/repositories/${image_info[0]}/tags/${image_info[1]}"
+          echo $image_url
+          if $(curl -s -f -lSL $image_url); then
             echo "docker image exists"
           else
             echo "docker image does not exist"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,11 @@ jobs:
           docker login -u $DOCKER_USER -p $DOCKER_PASS
 
       - run: |
+          cd wordpress-k8s-rds
+          image_name=$(grep '"image":' bundle.cnab  | awk -F': ' '{print $2}' | awk -F'\"' '{print $2}')
+          echo $image_name
+      - run: |
+          echo $image_name
           cd wordpress-k8s-rds/cnab
           docker_image=bitnami/wordpress-k8s-rds-cnab:devel
           docker build -t ${docker_image} .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,3 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: |
-        docker login -u $DOCKER_USER -p $DOCKER_PASS
-
-      - run: |
-        cd wordpress-k8s-rds/cnab
-        docker build -t test-todo:$CIRCLE_BRANCH .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
           FS=':' read -r -a image_info <<< ${image_name}
 
           image_url="https://index.docker.io/v1/repositories/${image_info[0]}/tags/${image_info[1]}"
+          echo $image_name
           echo $image_url
           if $(curl -s -f -lSL $image_url); then
             echo "docker image exists"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,4 +7,4 @@ jobs:
       - setup_remote_docker
       - checkout
       - run: |
-        docker login -u $DOCKER_USER -p $DOCKER_PASS
+         docker login -u $DOCKER_USER -p $DOCKER_PASS

--- a/wordpress-k8s-rds/bundle.cnab
+++ b/wordpress-k8s-rds/bundle.cnab
@@ -24,7 +24,7 @@ Hash: SHA256
   "invocationImages": [
     {
       "imageType": "docker",
-      "image": "bitnami/wordpress-k8s-rds-cnab:d45fe12775328fc4c843f2840f6988f6255a6a02-buu"
+      "image": "bitnami/wordpress-k8s-rds-cnab:d45fe12775328fc4c843f2840f6988f6255a6a02"
     }
   ],
   "images": [],

--- a/wordpress-k8s-rds/bundle.cnab
+++ b/wordpress-k8s-rds/bundle.cnab
@@ -24,7 +24,7 @@ Hash: SHA256
   "invocationImages": [
     {
       "imageType": "docker",
-      "image": "bitnami/wordpress-k8s-rds-cnab:d45fe12775328fc4c843f2840f6988f6255a6a02"
+      "image": "bitnami/wordpress-k8s-rds-cnab:d45fe12775328fc4c843f2840f6988f6255a6a02-buu"
     }
   ],
   "images": [],


### PR DESCRIPTION
Simple circle-ci workflow that will run on master and will build the image in the repo, tagging it as the image name present in the bundle.cnab file . Then it pushes the image upstream only if this image is not yet present upstream (see comment in the code). 

This job is basically a safety net while we implement a release process. It helps in the case in which the developer forgets to push the latest images of a modified bundle. The CI will take care of being sure that the images are pushed.

The main drawback is that the push happens after the code is added by I think that for simplicity sake and taking into account that this is a temporary measure we can accept that risk.